### PR TITLE
Performance improvement

### DIFF
--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -1751,12 +1751,9 @@ def _genericPyDirectInputChecks(
     '''
     @functools.wraps(wrappedFunction)
     def wrapper(*args: _PS.args, **kwargs: _PS.kwargs) -> _RT:
-        funcArgs: dict[str, Any] = (
-            inspect.getcallargs(wrappedFunction, *args, **kwargs)
-        )
         _failSafeCheck()
         returnVal: _RT = wrappedFunction(*args, **kwargs)
-        _handlePause(funcArgs.get("_pause"))
+        _handlePause(kwargs['_pause'] if '_pause' in kwargs else None)
         return returnVal
     return wrapper
 # ------------------------------------------------------------------------------

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 # native imports
 import functools
-import inspect
 import sys
 import time
 from collections.abc import Generator, Sequence

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 # native imports
 import functools
+import inspect
 import sys
 import time
 from collections.abc import Generator, Sequence
@@ -1750,9 +1751,16 @@ def _genericPyDirectInputChecks(
     '''
     @functools.wraps(wrappedFunction)
     def wrapper(*args: _PS.args, **kwargs: _PS.kwargs) -> _RT:
+        if '_pause' in kwargs:
+            _pause = kwargs['_pause']
+        else:
+            funcArgs: dict[str, Any] = (
+                inspect.getcallargs(wrappedFunction, *args, **kwargs)
+            )
+           _pause = funcArgs.get("_pause")
         _failSafeCheck()
         returnVal: _RT = wrappedFunction(*args, **kwargs)
-        _handlePause(kwargs['_pause'] if '_pause' in kwargs else None)
+        _handlePause(_pause)
         return returnVal
     return wrapper
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
I was having significant overhead from inspect.getcallargs() in _genericPyDirectInputChecks. I don't understand why such an expensive function is necessary in this case as a simple if statement seems to achieve very similar functionality.